### PR TITLE
add `open-contest` command to open contest page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
+/.at_coder_friends.yml
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     at_coder_friends (0.3.2)
+      launchy (~> 2.4.3)
       mechanize (~> 2.0)
 
 GEM
@@ -14,12 +15,14 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.3.1)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.8)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.1.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     mechanize (2.7.6)
       domain_name (~> 0.5, >= 0.5.1)
       http-cookie (~> 1.0)
@@ -31,12 +34,14 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     mini_portile2 (2.4.0)
     net-http-digest_auth (1.4.1)
-    net-http-persistent (3.0.0)
+    net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.4-x64-mingw32)
       mini_portile2 (~> 2.4.0)
     ntlm-http (0.1.1)
     public_suffix (3.0.3)
@@ -62,7 +67,7 @@ GEM
     simplecov-html (0.10.2)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -82,4 +87,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ at_coder_friends setup     /path/to/contest
 
 Creates contest folder, and generates example data and source skeletons into the folder.
 
+### Open Contest Page
+
+```
+at_coder_friends open-contest  /path/to/contest/source_file
+```
+
+Opens the contet page which the contest folder linked to.
 
 ### Run first test case
 

--- a/at_coder_friends.gemspec
+++ b/at_coder_friends.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'mechanize', '~> 2.0'
+  spec.add_dependency 'launchy', '~> 2.4.3'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/at_coder_friends/cli.rb
+++ b/lib/at_coder_friends/cli.rb
@@ -11,10 +11,11 @@ module AtCoderFriends
     OPTION_BANNER =
       <<~TEXT
         Usage:
-          at_coder_friends setup    path/contest       # setup contest folder
-          at_coder_friends test-one path/contest/src   # run 1st test case
-          at_coder_friends test-all path/contest/src   # run all test cases
-          at_coder_friends submit   path/contest/src   # submit source code
+          at_coder_friends setup        path/contest       # setup contest folder
+          at_coder_friends test-one     path/contest/src   # run 1st test case
+          at_coder_friends test-all     path/contest/src   # run all test cases
+          at_coder_friends submit       path/contest/src   # submit source code
+          at_coder_friends open-contest path/contest/src   # open contest page
         Options:
       TEXT
     STATUS_SUCCESS  = 0
@@ -72,6 +73,8 @@ module AtCoderFriends
         judge_one(path, id)
       when 'judge-all'
         judge_all(path)
+      when 'open-contest'
+        open_contest(path)
       else
         raise ParamError, "unknown command: #{command}"
       end
@@ -117,6 +120,10 @@ module AtCoderFriends
 
     def judge_all(path)
       JudgeTestRunner.new(path).judge_all
+    end
+
+    def open_contest(path)
+      ScrapingAgent.new(contest_name(path), @config).open_contest
     end
   end
 end

--- a/lib/at_coder_friends/scraping_agent.rb
+++ b/lib/at_coder_friends/scraping_agent.rb
@@ -4,6 +4,7 @@ require 'uri'
 require 'mechanize'
 require 'logger'
 require 'English'
+require 'launchy'
 
 module AtCoderFriends
   # scrapes AtCoder contest site and
@@ -142,6 +143,10 @@ module AtCoderFriends
       form.add_field!('data.LanguageId', lang_id)
       form.field_with(name: 'sourceCode').value = src
       form.submit
+    end
+
+    def open_contest
+      Launchy.open(contest_url(''))
     end
   end
 end

--- a/spec/at_coder_friends/cli_spec.rb
+++ b/spec/at_coder_friends/cli_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe AtCoderFriends::CLI do
 
   USAGE = <<~TEXT
     Usage:
-      at_coder_friends setup    path/contest       # setup contest folder
-      at_coder_friends test-one path/contest/src   # run 1st test case
-      at_coder_friends test-all path/contest/src   # run all test cases
-      at_coder_friends submit   path/contest/src   # submit source code
+      at_coder_friends setup        path/contest       # setup contest folder
+      at_coder_friends test-one     path/contest/src   # run 1st test case
+      at_coder_friends test-all     path/contest/src   # run all test cases
+      at_coder_friends submit       path/contest/src   # submit source code
+      at_coder_friends open-contest path/contest/src   # open contest page
     Options:
         -v, --version                    Display version.
   TEXT


### PR DESCRIPTION
 Add a command,  `open-contest`, that is useful when you want to open contest page from CLI.

By executing the command below

```
$ at_coder_friends open-contest /path/to/contest
```

the page for the contest is opened in your default browser.