### PR TITLE
replace hspace with ' '

### DIFF
--- a/lib/at_coder_friends/parser/input_format.rb
+++ b/lib/at_coder_friends/parser/input_format.rb
@@ -56,6 +56,7 @@ module AtCoderFriends
           .gsub('&gt;', '>')
           .gsub('&lt;', '<')
           .gsub('\\ ', ' ')
+          .gsub(/\\hspace\{\d+pt\}/, ' ')
           .gsub('\\(', '')
           .gsub('\\)', '')
           .gsub('\\lvert', '|')


### PR DESCRIPTION
https://atcoder.jp/contests/abc185/tasks/abc185_d 等で、空白として \hspace{Xpt} が使われているため、
\hspace{Xpt} を ' ' に置換します。